### PR TITLE
Price formatter

### DIFF
--- a/src/components/CoinDetails.vue
+++ b/src/components/CoinDetails.vue
@@ -644,14 +644,21 @@ export default {
             // return this.currentDate
         },
         formatPrice(value) {
-            // Create our number formatter.
-            var formatter = new Intl.NumberFormat('en-US', {
+            let formatOptions = {
                 style: 'currency',
                 currency: 'USD',
                 // These options are needed to round to whole numbers if that's what you want.
                 //minimumFractionDigits: 0, // (this suffices for whole numbers, but will print 2500.10 as $2,500.1)
                 //maximumFractionDigits: 0, // (causes 2500.99 to be printed as $2,501)
-            });
+            }
+
+            if (value < 0.01) {
+                formatOptions.minimumSignificantDigits = 2
+                formatOptions.maximumSignificantDigits = 2
+            }
+
+            // Create our number formatter
+            var formatter = new Intl.NumberFormat('en-US', formatOptions);
 
             return formatter.format(value)
         },

--- a/src/views/CoinList.vue
+++ b/src/views/CoinList.vue
@@ -268,20 +268,20 @@ export default {
     },
     formatPrice(value) {
       // Create our number formatter.
-    
-      if (value < 10) {
-        var formatter = new Intl.NumberFormat('en-US', {
-          minimumFractionDigits: 3,
-          style: 'currency',
-          currency: this.currency,
-        });
-      } else {
-        var formatter = new Intl.NumberFormat('en-US', {
-          minimumFractionDigits: 2,
-          style: 'currency',
-          currency: this.currency,
-        });
+      let formatOptions = {
+        minimumFractionDigits: 2,
+        style: 'currency',
+        currency: this.currency,
       }
+    
+      // Such small floats should have a minimum significant digits visible
+      if (value < 10) formatOptions.minimumFractionDigits = 3
+      if (value < 0.01) {
+        formatOptions.minimumSignificantDigits = 2
+        formatOptions.maximumSignificantDigits = 2
+      }
+
+      var formatter = new Intl.NumberFormat('en-US', formatOptions);
 
       return formatter.format(value)
     },


### PR DESCRIPTION
So the price format function for CoinList and CoinDetails will show very low values to 2 significant figures. Hope it's what you wanted!
But now prices of some of the lowest value coins can wrap vertically if the display is less than ~400px

![Screenshot from 2021-05-31 15-02-56](https://user-images.githubusercontent.com/61043071/120153503-60e10100-c221-11eb-97c9-0b6489fdfadd.png)
![Screenshot from 2021-05-31 15-05-04](https://user-images.githubusercontent.com/61043071/120153685-9980da80-c221-11eb-9fc6-4990629d7ca5.png)
