### PR TITLE
Bug fix: CoinDetails had some data uninitialised due to error in a formatting function

### DIFF
--- a/src/components/CoinDetails.vue
+++ b/src/components/CoinDetails.vue
@@ -644,14 +644,21 @@ export default {
             // return this.currentDate
         },
         formatPrice(value) {
-            // Create our number formatter.
-            var formatter = new Intl.NumberFormat('en-US', {
+            let formatOptions = {
                 style: 'currency',
                 currency: 'USD',
                 // These options are needed to round to whole numbers if that's what you want.
                 //minimumFractionDigits: 0, // (this suffices for whole numbers, but will print 2500.10 as $2,500.1)
                 //maximumFractionDigits: 0, // (causes 2500.99 to be printed as $2,501)
-            });
+            }
+
+            if (value < 0.01) {
+                formatOptions.minimumSignificantDigits = 2
+                formatOptions.maximumSignificantDigits = 2
+            }
+
+            // Create our number formatter
+            var formatter = new Intl.NumberFormat('en-US', formatOptions);
 
             return formatter.format(value)
         },

--- a/src/components/CoinDetails.vue
+++ b/src/components/CoinDetails.vue
@@ -673,7 +673,7 @@ export default {
             return formatter.format(value)
         },
         numberWithCommas(x) {
-            return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+            return x ? x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") : null;
         },
         formatPercentGain(value) {
 

--- a/src/views/CoinList.vue
+++ b/src/views/CoinList.vue
@@ -268,20 +268,20 @@ export default {
     },
     formatPrice(value) {
       // Create our number formatter.
-    
-      if (value < 10) {
-        var formatter = new Intl.NumberFormat('en-US', {
-          minimumFractionDigits: 3,
-          style: 'currency',
-          currency: this.currency,
-        });
-      } else {
-        var formatter = new Intl.NumberFormat('en-US', {
-          minimumFractionDigits: 2,
-          style: 'currency',
-          currency: this.currency,
-        });
+      let formatOptions = {
+        minimumFractionDigits: 2,
+        style: 'currency',
+        currency: this.currency,
       }
+    
+      // Such small floats should have a minimum significant digits visible
+      if (value < 10) formatOptions.minimumFractionDigits = 3
+      if (value < 0.01) {
+        formatOptions.minimumSignificantDigits = 2
+        formatOptions.maximumSignificantDigits = 2
+      }
+
+      var formatter = new Intl.NumberFormat('en-US', formatOptions);
 
       return formatter.format(value)
     },


### PR DESCRIPTION
Yo again :)
Check the screenshot --
![Screenshot from 2021-05-31 20-03-13](https://user-images.githubusercontent.com/61043071/120191370-6dc71a00-c24c-11eb-9049-9ea04ddd590f.png)
There was no check for null case in numberWithCommas() - so an error was being thrown from it into the try block which was initialising some coin info, causing some data to be uninitialised.
So your API sometimes doesn't return a number for market_data.total_supply or max_supply